### PR TITLE
Add Jetpack Compose UI skeleton

### DIFF
--- a/app/src/main/java/com/rururi/codextestapp/MainActivity.kt
+++ b/app/src/main/java/com/rururi/codextestapp/MainActivity.kt
@@ -5,12 +5,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.rururi.codextestapp.ui.GameScreen
+import com.rururi.codextestapp.ui.GameUiState
 import com.rururi.codextestapp.ui.theme.CodexTestAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,14 +18,17 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             CodexTestAppTheme {
-//                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-//                    Greeting(
-//                        name = "Android",
-//                        modifier = Modifier.padding(innerPadding)
-//                    )
-//                }
+                GameScreen(state = GameUiState(), modifier = Modifier.fillMaxSize())
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    CodexTestAppTheme {
+        GameScreen(state = GameUiState(), modifier = Modifier.fillMaxSize())
     }
 }
 

--- a/app/src/main/java/com/rururi/codextestapp/ui/GameScreen.kt
+++ b/app/src/main/java/com/rururi/codextestapp/ui/GameScreen.kt
@@ -1,0 +1,62 @@
+package com.rururi.codextestapp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.rururi.codextestapp.ui.theme.CodexTestAppTheme
+
+@Composable
+fun GameScreen(
+    state: GameUiState,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(text = "Score: ${state.score}")
+        Spacer(modifier = Modifier.height(16.dp))
+        Box(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "Game Board")
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Button(onClick = { /* TODO start action */ }) {
+                Text(text = "Start")
+            }
+            Button(onClick = { /* TODO reset action */ }) {
+                Text(text = "Reset")
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun GameScreenPreview() {
+    CodexTestAppTheme {
+        GameScreen(state = GameUiState())
+    }
+}

--- a/app/src/main/java/com/rururi/codextestapp/ui/GameUiState.kt
+++ b/app/src/main/java/com/rururi/codextestapp/ui/GameUiState.kt
@@ -1,0 +1,5 @@
+package com.rururi.codextestapp.ui
+
+data class GameUiState(
+    val score: Int = 0
+)


### PR DESCRIPTION
## Summary
- add `GameScreen` composable with score, board placeholder and buttons
- define `GameUiState` data class
- update `MainActivity` to show `GameScreen`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68619b6e35088333a20ee971a0933f2d